### PR TITLE
Pulling Operation Type Property from Config file.

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/authzed/client/deployment/DevServicesAuthzedConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/authzed/client/deployment/DevServicesAuthzedConfig.java
@@ -118,5 +118,13 @@ public class DevServicesAuthzedConfig {
      */
     @ConfigItem
     public MetricsConfig metrics;
+    
+     /**
+     * operationType configuration
+     */
+    @ConfigItem(defaultValue = "CREATE")
+    public String operationType;
+    
+    
 
 }

--- a/deployment/src/main/java/io/quarkiverse/authzed/client/deployment/DevServicesAuthzedProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/authzed/client/deployment/DevServicesAuthzedProcessor.java
@@ -60,6 +60,7 @@ public class DevServicesAuthzedProcessor {
 
     private static final Logger log = Logger.getLogger(DevServicesAuthzedProcessor.class);
     static final String CONFIG_PREFIX = "quarkus.authzed.";
+    public static final String OPERATION = "OPERATION_";
 
     static final String GRPC_URL_CONFIG_KEY = CONFIG_PREFIX + "url";
     static final String HTTP_URL_CONFIG_KEY = CONFIG_PREFIX + "http.url";
@@ -219,7 +220,7 @@ public class DevServicesAuthzedProcessor {
                                 Uni<WriteRelationshipsResponse> writeRelationshipRespone = client.v1().permissionService()
                                         .writeRelationships(WriteRelationshipsRequest.newBuilder()
                                                 .addUpdates(RelationshipUpdate.newBuilder()
-                                                        .setOperation(Operation.OPERATION_CREATE)
+                                                        .setOperation(Operation.valueOf(OPERATION.concat(devServicesConfig.operationType.toUpperCase())))
                                                         .setRelationship(Tuples.parseRelationship(tuple))
                                                         .build())
                                                 .build());


### PR DESCRIPTION
Pulling Operation Type Property from Config file. This will enable developers to update the operation type of the SpiceDB Tuples. Current Value is Create because of which if the same tuples are added multiple times, it throws an exception. 