### PR TITLE
Added IOThreadClientInterceptor to the AuthzedContext to use IO threads

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/authzed/client/AuthzedContext.java
+++ b/runtime/src/main/java/io/quarkiverse/authzed/client/AuthzedContext.java
@@ -13,7 +13,6 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.quarkiverse.authzed.BearerToken;
 import io.quarkiverse.authzed.runtime.config.AuthzedConfig;
 import io.quarkus.grpc.runtime.supports.IOThreadClientInterceptor;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 
 public class AuthzedContext implements AutoCloseable {
 
@@ -35,7 +34,6 @@ public class AuthzedContext implements AutoCloseable {
 
     private static ManagedChannel createChannel(AuthzedConfig config) {
         NettyChannelBuilder builder = NettyChannelBuilder.forAddress(config.url.getHost(), config.url.getPort())
-                .directExecutor().offloadExecutor(Infrastructure.getDefaultExecutor())
                 .intercept(new IOThreadClientInterceptor());
 
         if (config.tlsEnabled) {


### PR DESCRIPTION
This is a fix for https://github.com/quarkiverse/quarkus-authzed-client/issues/50

The code changes are inspired from [https://github.com/quarkusio/quarkus/blob/bdc776daa8bda180948dce0baa1d06acde9cbd3e/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java#L169]