### PR TITLE
Stop injecting runtime config into build processor

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/authzed/client/deployment/AuthzedClientProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/authzed/client/deployment/AuthzedClientProcessor.java
@@ -8,7 +8,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 import io.quarkiverse.authzed.client.AuthzedClient;
 import io.quarkiverse.authzed.runtime.AuthzedRecorder;
-import io.quarkiverse.authzed.runtime.config.AuthzedConfig;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -31,7 +30,6 @@ class AuthzedClientProcessor {
     @Record(RUNTIME_INIT)
     ServiceStartBuildItem registerSyntheticBeans(
             AuthzedBuildTimeConfig buildTimeConfig,
-            AuthzedConfig runtimeConfig,
             SslNativeConfigBuildItem sslNativeConfig,
             VertxBuildItem vertx,
             Optional<TlsRegistryBuildItem> tlsRegistryBuildItem,
@@ -50,7 +48,7 @@ class AuthzedClientProcessor {
                 SyntheticBeanBuildItem.configure(AuthzedClient.class)
                         .scope(ApplicationScoped.class)
                         .setRuntimeInit()
-                        .runtimeValue(recorder.createClient(runtimeConfig, tlsRegistrySupplier))
+                        .runtimeValue(recorder.createClient(tlsRegistrySupplier))
                         .done());
 
         return new ServiceStartBuildItem("authzed-client");

--- a/runtime/src/main/java/io/quarkiverse/authzed/runtime/AuthzedRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/authzed/runtime/AuthzedRecorder.java
@@ -2,6 +2,8 @@ package io.quarkiverse.authzed.runtime;
 
 import java.util.function.Supplier;
 
+import jakarta.inject.Inject;
+
 import io.quarkiverse.authzed.client.AuthzedClient;
 import io.quarkiverse.authzed.runtime.config.AuthzedConfig;
 import io.quarkus.runtime.RuntimeValue;
@@ -11,8 +13,19 @@ import io.quarkus.tls.TlsConfigurationRegistry;
 @Recorder
 public class AuthzedRecorder {
 
-    public RuntimeValue<AuthzedClient> createClient(AuthzedConfig config, Supplier<TlsConfigurationRegistry> tlsRegistry) {
-        AuthzedClient client = new AuthzedClient(config, tlsRegistry.get());
+    private final RuntimeValue<AuthzedConfig> configValue;
+
+    @Inject
+    public AuthzedRecorder(RuntimeValue<AuthzedConfig> configValue) {
+        this.configValue = configValue;
+    }
+
+    AuthzedConfig getConfig() {
+        return configValue.getValue();
+    }
+
+    public RuntimeValue<AuthzedClient> createClient(Supplier<TlsConfigurationRegistry> tlsRegistry) {
+        AuthzedClient client = new AuthzedClient(getConfig(), tlsRegistry.get());
         return new RuntimeValue<>(client);
     }
 


### PR DESCRIPTION
Adheres to the advice given by, and removes, the warning during startup.